### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/caasjj_observable/keywords.txt
+++ b/caasjj_observable/keywords.txt
@@ -12,11 +12,11 @@ Observable	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-Configure	        KEYWORD2
+Configure	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-ENABLED			LITERAL1
-DISABLED	    LITERAL1
+ENABLED	LITERAL1
+DISABLED	LITERAL1

--- a/caasjj_pid/keywords.txt
+++ b/caasjj_pid/keywords.txt
@@ -12,21 +12,21 @@ PID	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-Configure	        KEYWORD2
+Configure	KEYWORD2
 SetLoopConstants	KEYWORD2
-UpdateLoop	        KEYWORD2
+UpdateLoop	KEYWORD2
 SetOutputLimiits	KEYWORD2
-Enable	            KEYWORD2
+Enable	KEYWORD2
 EnableDataUpload	KEYWORD2
-GetKp	            KEYWORD2
-GetKi	            KEYWORD2
-GetKd	            KEYWORD2
-GetMode	            KEYWORD2
-GetDirection	    KEYWORD2
+GetKp	KEYWORD2
+GetKi	KEYWORD2
+GetKd	KEYWORD2
+GetMode	KEYWORD2
+GetDirection	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-ENABLED			LITERAL1
-DISABLED	    LITERAL1
+ENABLED	LITERAL1
+DISABLED	LITERAL1

--- a/caasjj_sampler/keywords.txt
+++ b/caasjj_sampler/keywords.txt
@@ -12,15 +12,15 @@ Sampler	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-start	        KEYWORD2
-stop 			KEYWORD2
+start	KEYWORD2
+stop	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-TIMER			LITERAL1
+TIMER	LITERAL1
 TIMER_VECTOR	LITERAL1
-timer_setup		LITERAL1
-timer_start	    LITERAL1
-timer_stop		LITERAL1
+timer_setup	LITERAL1
+timer_start	LITERAL1
+timer_stop	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When the specification is not followed it causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords